### PR TITLE
Add validator tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Validator CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🤖 LLM QA Validator Tool
 
-A plug-and-play QA automation tool designed to validate and improve LLM, RAG, or model-based pipelines.  
+A plug-and-play QA automation tool designed to validate and improve LLM, RAG, or model-based pipelines.
+Example LLM apps are provided under `model_to_validate/` so you can try the validator end-to-end.
 It scans code using a local LLM via [Ollama](https://ollama.com) and provides:
 - Test coverage audit
 - Prompt risk analysis
@@ -17,10 +18,13 @@ llm_validator/
 ├── requirements.txt
 ├── prompts/
 │   └── qa_unified_prompt.txt
-├── model_to_validate/   
-│    └── LLM1 # Model to validate
-│           ├── app.py
-│           └── prompts_used.json
+├── model_to_validate/
+│   ├── sentiment_analysis/
+│   │   ├── app.py
+│   │   └── prompts_used.json
+│   └── sumarrizer/
+│       ├── LLM.py
+│       └── prompts_used.json
 ├── results/
 │   └── validation_report_<model_name>_<timestamp>.md
 ├── generated/     # Generated files
@@ -121,6 +125,14 @@ You'll also get a generation summary like:
 | No model found | Run `ollama pull llama3` |
 | Output empty | Ensure prompt file exists and input code is valid |
 | Prompt injection warning | Refactor or use generated prompts |
+
+---
+
+### Running Tests
+
+```bash
+pytest -q
+```
 
 ---
 

--- a/model_to_validate/README.md
+++ b/model_to_validate/README.md
@@ -1,0 +1,15 @@
+# Example LLM Applications
+
+This folder contains small example projects that you can run through the validator.
+Each subfolder represents a separate application with its own prompts and code.
+
+- `sentiment_analysis/` – uses the HuggingFace `transformers` pipeline to analyse
+  sentiment.
+- `sumarrizer/` – a miniature RAG style summarizer that embeds text with
+  `sentence-transformers` and retrieves similar documents.
+
+Run the validator against all apps:
+
+```bash
+python validator.py --mode=validate --dir model_to_validate/ --model llama3
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 transformers==4.41.1      # For sentiment-analysis pipeline in app.py
 pyyaml==6.0.1             # For reading manifest.yaml
 ollama                    # Assumes Ollama CLI is installed separately
+pytest
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,59 @@
+import argparse
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import validator
+
+
+def test_estimate_token_count():
+    text = "one two three four"
+    assert validator.estimate_token_count(text) == int(4 * 1.3)
+
+
+def test_load_code_sources_file(tmp_path):
+    f = tmp_path / "file.py"
+    f.write_text("print('hi')")
+    result = validator.load_code_sources(file=str(f))
+    assert result == ["print('hi')"]
+
+
+def test_load_code_sources_dir(tmp_path):
+    d = tmp_path / "src"
+    d.mkdir()
+    (d / "a.py").write_text("a")
+    (d / "b.py").write_text("b")
+    sources = validator.load_code_sources(directory=str(d))
+    assert sorted(sources) == ["a", "b"]
+
+
+def test_extract_app_name(tmp_path):
+    app_dir = tmp_path / "myapp"
+    app_dir.mkdir()
+    f = app_dir / "main.py"
+    f.write_text("pass")
+    assert validator.extract_app_name(str(f)) == "myapp"
+    assert validator.extract_app_name(str(app_dir)) == "myapp"
+
+
+def test_validate_creates_report(tmp_path, monkeypatch):
+    prompts_dir = tmp_path / "prompts"
+    prompts_dir.mkdir()
+    prompt_file = prompts_dir / "qa_unified_prompt.txt"
+    prompt_file.write_text("Prompt template")
+    results_dir = tmp_path / "results"
+    code_file = tmp_path / "app.py"
+    code_file.write_text("print('x')")
+
+    monkeypatch.setattr(validator, "PROMPTS_DIR", prompts_dir)
+    monkeypatch.setattr(validator, "VALIDATION_PROMPT_FILE", prompt_file)
+    monkeypatch.setattr(validator, "RESULTS_DIR", results_dir)
+
+    monkeypatch.setattr(validator, "run_ollama", lambda prompt, model: "output")
+
+    args = argparse.Namespace(file=str(code_file), dir=None, manifest=False, model="demo")
+    validator.validate(args)
+
+    files = list(results_dir.iterdir())
+    assert len(files) == 1
+    assert files[0].name.startswith("validation_report_demo_")
+    assert files[0].read_text() == "output"


### PR DESCRIPTION
## Summary
- add unit tests for `validator.py`
- ship example apps info under `model_to_validate/`
- update README with example apps, test instructions and new folder layout
- add pytest to requirements
- create GitHub Actions workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850058115e4832197e10ead16ff5f77